### PR TITLE
PDF code: Update PDFDocument import

### DIFF
--- a/codigo/Live25/pdf/pdf_parser.py
+++ b/codigo/Live25/pdf/pdf_parser.py
@@ -1,4 +1,5 @@
-from pdfminer.pdfparser import PDFParser, PDFDocument
+from pdfminer.pdfparser import PDFParser
+from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.converter import PDFPageAggregator
 from pdfminer.layout import LAParams, LTTextBox, LTTextLine


### PR DESCRIPTION
2013/11/13: Bugfixes and minor improvements. As of November 2013, there were a few changes made to the
PDFMiner API prior to October 2013. This is the result of code restructuring. Here is a list of the changes:
– PDFDocument class is moved to pdfdocument.py

Outra coisa que acho que pode modificar, mas não tenho certeza:
2014/03/24: Bugfixes and improvements for fauly PDFs. API changes:
– PDFDocument.initialize() method is removed and no longer needed. A password is given as an
argument of a PDFDocument constructor.